### PR TITLE
Reduce outer padding

### DIFF
--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -10,7 +10,7 @@
 	--color-overlay-6: color-mix(in srgb, var(--color-text-0) 35%, transparent);
 	--color-overlay-7: color-mix(in srgb, var(--color-text-0) 40%, transparent);
 
-	--pad: 1.25rem;
+	--pad: 0.75rem;
 	--gap: 0.75rem;
 	scroll-behavior: smooth;
 }

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -10,8 +10,8 @@
 	--color-overlay-6: color-mix(in srgb, var(--color-text-0) 35%, transparent);
 	--color-overlay-7: color-mix(in srgb, var(--color-text-0) 40%, transparent);
 
-	--pad: 0.75rem;
 	--gap: 0.75rem;
+	--pad: var(--gap);
 	scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
Quite a small change in code, but I believe that it does improve it for the end user, by giving them more space to work.

Before:
![image](https://github.com/Akademiaapp/frontend/assets/85990359/01e9fb59-0b87-4743-9d7a-246d93a24f43)
After:
![image](https://github.com/Akademiaapp/frontend/assets/85990359/01b315f7-7a83-4ef0-b961-17381a62575f)

Before on a small screen:
![image](https://github.com/Akademiaapp/frontend/assets/85990359/ee7f351a-923d-4d3e-a205-f13334cd0804)
After on a small screen:
![image](https://github.com/Akademiaapp/frontend/assets/85990359/57ac6164-348e-4526-b102-885bb8a1e363)

