### PR TITLE
Improve appearence of the Math box

### DIFF
--- a/src/lib/components/MathBox.svelte
+++ b/src/lib/components/MathBox.svelte
@@ -10,13 +10,18 @@
 	export let value = '';
 
 	export let expression = '';
+
 	export let onFocus = () => {};
+	export let onDelete = () => {};
 
 	$: updateValue(expression);
 
 	function updateValue(expression) {
+		expression = expression == 0 ? '' : expression;
 		if (expression == value) return;
+		console.log(expression, value);
 		mf?.setValue(expression);
+		value = expression;
 		handleKeyDown({ data: '' });
 	}
 
@@ -40,8 +45,8 @@
 	}
 
 	function handleKeyDown(event) {
-		if (event.data === 'delh	 eteContentBackward') {
-			event.preventDefault();
+		if (event.data === 'deleteContentBackward') {
+			// event.preventDefault();
 		}
 
 		if (event.data === 'insertLineBreak') {
@@ -51,7 +56,6 @@
 		}
 
 		if (!mf || !mf.expression) return;
-
 		value = mf.value;
 
 		nerdamer.set('SOLUTIONS_AS_OBJECT', true);
@@ -88,6 +92,8 @@
 	}
 	let mf: MathfieldElement;
 
+	let oldValue = value;
+
 	onMount(() => {
 		try {
 			setTimeout(() => {
@@ -100,24 +106,31 @@
 		const mathVirtualKeyboard = window.mathVirtualKeyboard;
 
 		mf.mathVirtualKeyboardPolicy = 'manual';
+
+		MathfieldElement.soundsDirectory = null;
 		mf.addEventListener('focusin', () => {
 			if (editable) {
 				mathVirtualKeyboard.show();
 				onFocus();
 			}
 		});
-		mf.addEventListener('focusout', () => {
+		mf.addEventListener('focusout', (ev) => {
 			if (editable) {
 				mathVirtualKeyboard.hide();
 			}
+			if (mf?.value === '') onDelete();
 		});
 
 		mf.addEventListener('input', handleKeyDown);
 
 		mf.addEventListener('keydown', (ev) => {
 			if (ev.key == 'Backspace') {
-				ev.preventDefault();
+				if (oldValue == '') {
+					onDelete();
+					document.querySelector('.tiptap').focus({ preventScroll: true });
+				}
 			}
+			oldValue = value;
 		});
 
 		mf.addEventListener('move-out', (event) => {
@@ -131,6 +144,9 @@
 				$editor.commands.setTextSelection($editor.state.selection.$from.pos);
 			}
 		});
+
+		// mf.selection = 0;
+		// mf.blur();
 	});
 
 	export let latexResult = null;

--- a/src/lib/components/MathBox.svelte
+++ b/src/lib/components/MathBox.svelte
@@ -6,6 +6,7 @@
 	import { editor } from '../../routes/workspace/editor/editorStore';
 	import { Assignment, AssignmentAnswer, AssignmentStatus } from '@/api/fileClasses';
 	import { currentFile } from '@/api/apiStore';
+	import { cn } from '@/utils';
 	export let value = '';
 
 	export let expression = '';
@@ -153,12 +154,12 @@
 on:keydown={handleKeyDown} /> -->
 
 <button
-	class="box-border cursor-auto overflow-hidden border border-transparent pr-2 hover:border-foreground/10"
+	class={'box-border cursor-auto overflow-hidden border border-transparent pr-2 ' +
+		(editable ? ' hover:border-foreground/10' : '')}
 	bind:this={cont}
 >
 	<math-field
-		class={'rounded-none bg-background p-1 px-2 text-foreground outline-none' +
-			(editable ? ' ' : '')}
+		class="rounded-none bg-background p-1 px-2 text-foreground outline-none"
 		readonly={!editable}
 		bind:this={mf}
 	>

--- a/src/lib/components/MathBox.svelte
+++ b/src/lib/components/MathBox.svelte
@@ -152,10 +152,13 @@
 <!-- AssignmentStatusAssignmentStatuse="text" class="m-20 bg-background p-3 text-3xl" bind:value
 on:keydown={handleKeyDown} /> -->
 
-<button class="cursor-auto overflow-hidden rounded-sm border bg-background pr-2" bind:this={cont}>
+<button
+	class="box-border cursor-auto overflow-hidden border border-transparent pr-2 hover:border-foreground/10"
+	bind:this={cont}
+>
 	<math-field
 		class={'rounded-none bg-background p-1 px-2 text-foreground outline-none' +
-			(editable ? ' border-b-2 border-b-primary/50 focus:border-b-primary/100' : '')}
+			(editable ? ' ' : '')}
 		readonly={!editable}
 		bind:this={mf}
 	>
@@ -182,3 +185,9 @@ on:keydown={handleKeyDown} /> -->
 		{/if}
 	</span>
 </button>
+
+<style>
+	button:has(math-field:focus) {
+		border: 1px solid hsl(var(--foreground) / 0.2);
+	}
+</style>

--- a/src/routes/workspace/editor/tiptap/extensions/Math.svelte
+++ b/src/routes/workspace/editor/tiptap/extensions/Math.svelte
@@ -7,13 +7,13 @@
 	export let getPos: NodeViewProps['getPos'];
 	import MathBox from '@/components/MathBox.svelte';
 	import { NodeViewWrapper } from 'svelte-tiptap';
+	import { NodeRange } from '@tiptap/pm/model';
 
-	let value;
-
-	let startVal = node.attrs.count;
+	let startVal = node.attrs.count == 0 ? '' : node.attrs.count;
+	let value = startVal;
 
 	$: try {
-		updateAttributes({ count: value });
+		updateAttributes({ count: value == '' ? 0 : value });
 	} catch (e) {
 		console.error(e);
 	}
@@ -21,10 +21,15 @@
 	function focus() {
 		editor.commands.setNodeSelection(getPos());
 	}
+
+	function deleteNode() {
+		if (!getPos()) return;
+		editor.commands.deleteRange({ from: getPos(), to: getPos() + node.nodeSize });
+	}
 </script>
 
 <NodeViewWrapper as="span">
-	<MathBox bind:value onFocus={focus} expression={node.attrs.count}>
+	<MathBox bind:value onFocus={focus} onDelete={deleteNode}>
 		{startVal}
 	</MathBox>
 </NodeViewWrapper>

--- a/src/routes/workspace/editor/tiptap/extensions/Math.svelte
+++ b/src/routes/workspace/editor/tiptap/extensions/Math.svelte
@@ -24,9 +24,7 @@
 </script>
 
 <NodeViewWrapper as="span">
-	<button class="inline-flex" on:click={focus}>
-		<MathBox bind:value onFocus={focus} expression={node.attrs.count}>
-			{startVal}
-		</MathBox>
-	</button>
+	<MathBox bind:value onFocus={focus} expression={node.attrs.count}>
+		{startVal}
+	</MathBox>
 </NodeViewWrapper>


### PR DESCRIPTION
After multiple users expressed dissatisfaction with the visual appearance of the math box, I have tried to redesign it to have a more professional and sleek look.

Deafult - No outline:
![image](https://github.com/Akademiaapp/frontend/assets/85990359/d70c3069-cfdd-4ab5-aaf6-e62fe08841af)

Hover - Slight outline:
![image](https://github.com/Akademiaapp/frontend/assets/85990359/690e7221-64b7-4a17-b428-394317917d01)

Focus - Darker outline:
![image](https://github.com/Akademiaapp/frontend/assets/85990359/22a04ffd-ed19-4e46-9a5f-b734c3e26bbc)
